### PR TITLE
Set minter mutable

### DIFF
--- a/clients/js/src/generated/instructions/mintV2.ts
+++ b/clients/js/src/generated/instructions/mintV2.ts
@@ -249,7 +249,7 @@ export function mintV2(
   keys.push({
     pubkey: minterAccount.publicKey,
     isSigner: true,
-    isWritable: isWritable(minterAccount, false),
+    isWritable: isWritable(minterAccount, true),
   });
 
   // Nft Mint.

--- a/clients/js/test/defaultGuards/nftBurn.test.ts
+++ b/clients/js/test/defaultGuards/nftBurn.test.ts
@@ -65,7 +65,7 @@ test('it burns a specific NFT to allow minting', async (t) => {
   await assertBurnedNft(t, umi, nftToBurn, umi.identity);
 });
 
-test.skip('it allows minting even when the payer is different from the minter', async (t) => {
+test('it allows minting even when the payer is different from the minter', async (t) => {
   // Given a separate minter owns an NFT from a certain collection.
   const umi = await createUmi();
   const minter = generateSigner(umi);

--- a/idls/candy_guard.json
+++ b/idls/candy_guard.json
@@ -206,7 +206,7 @@
         },
         {
           "name": "minter",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "Minter account for validation and non-SOL fees."

--- a/programs/candy-guard/program/src/instructions/mint_v2.rs
+++ b/programs/candy-guard/program/src/instructions/mint_v2.rs
@@ -240,6 +240,7 @@ pub struct MintV2<'info> {
     payer: Signer<'info>,
 
     /// Minter account for validation and non-SOL fees.
+    #[account(mut)]
     minter: Signer<'info>,
 
     /// Mint account of the NFT. The account will be initialized if necessary.


### PR DESCRIPTION
This PR set the `minter` account mutable. This allows the minter to receive lamports (e.g., when the burn guard is used).