### PR TITLE
Skip revoke for pnft

### DIFF
--- a/programs/candy-machine-core/program/src/instructions/set_collection.rs
+++ b/programs/candy-machine-core/program/src/instructions/set_collection.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use mpl_token_metadata::state::{Metadata, TokenMetadataAccount};
 
 use crate::{
     approve_collection_authority_helper, cmp_pubkeys, constants::AUTHORITY_SEED,
@@ -22,6 +23,10 @@ pub fn set_collection(ctx: Context<SetCollection>) -> Result<()> {
         return err!(CandyError::MintMismatch);
     }
 
+    let collection_metadata_info = &accounts.collection_metadata;
+    let collection_metadata: Metadata =
+        Metadata::from_account_info(&collection_metadata_info.to_account_info())?;
+
     // revoking the existing collection authority
 
     let revoke_accounts = RevokeCollectionAuthorityHelperAccounts {
@@ -36,6 +41,7 @@ pub fn set_collection(ctx: Context<SetCollection>) -> Result<()> {
         revoke_accounts,
         candy_machine.key(),
         *ctx.bumps.get("authority_pda").unwrap(),
+        collection_metadata.token_standard,
     )?;
 
     // approving the new collection authority

--- a/programs/candy-machine-core/program/src/instructions/set_collection_v2.rs
+++ b/programs/candy-machine-core/program/src/instructions/set_collection_v2.rs
@@ -1,4 +1,5 @@
 use anchor_lang::{prelude::*, solana_program::sysvar};
+use mpl_token_metadata::state::{Metadata, TokenMetadataAccount};
 
 use crate::{
     approve_metadata_delegate, cmp_pubkeys, constants::AUTHORITY_SEED,
@@ -41,6 +42,10 @@ pub fn set_collection_v2(ctx: Context<SetCollectionV2>) -> Result<()> {
             *ctx.bumps.get("authority_pda").unwrap(),
         )?;
     } else {
+        let collection_metadata_info = &accounts.collection_metadata;
+        let collection_metadata: Metadata =
+            Metadata::from_account_info(&collection_metadata_info.to_account_info())?;
+
         // revoking the existing collection authority
 
         let revoke_accounts = RevokeCollectionAuthorityHelperAccounts {
@@ -55,6 +60,7 @@ pub fn set_collection_v2(ctx: Context<SetCollectionV2>) -> Result<()> {
             revoke_accounts,
             candy_machine.key(),
             *ctx.bumps.get("authority_pda").unwrap(),
+            collection_metadata.token_standard,
         )?;
         // bump the version of the account since we are setting a metadata delegate
         candy_machine.version = AccountVersion::V2;

--- a/programs/candy-machine-core/program/src/instructions/set_token_standard.rs
+++ b/programs/candy-machine-core/program/src/instructions/set_token_standard.rs
@@ -42,6 +42,7 @@ pub fn set_token_standard(ctx: Context<SetTokenStandard>, token_standard: u8) ->
             revoke_accounts,
             candy_machine.key(),
             *ctx.bumps.get("authority_pda").unwrap(),
+            collection_metadata.token_standard,
         )?;
 
         // approve a new metadata delegate


### PR DESCRIPTION
PR to skip the revoke of the "legacy" collection authority when the collection `NFT` has been migrated to `pNFT` and the candy machine account version is still `V1`.