### PR TITLE
Remove signer requirement

### DIFF
--- a/clients/js/src/defaultGuards/allowList.ts
+++ b/clients/js/src/defaultGuards/allowList.ts
@@ -1,5 +1,5 @@
 import { getSplSystemProgramId } from '@metaplex-foundation/mpl-essentials';
-import { publicKey, Signer } from '@metaplex-foundation/umi';
+import { PublicKey, publicKey } from '@metaplex-foundation/umi';
 import {
   AllowList,
   AllowListArgs,
@@ -78,7 +78,7 @@ export const allowListGuardManifest: GuardManifest<
       },
       { isWritable: false, publicKey: getSplSystemProgramId(context) },
       ...(args.minter !== undefined
-        ? [{ signer: args.minter, isWritable: false }]
+        ? [{ isWritable: false, publicKey: publicKey(args.minter) }]
         : []),
     ],
   }),
@@ -122,5 +122,5 @@ export type AllowListRouteArgs = AllowListArgs & {
   merkleProof: Uint8Array[];
 
   /** The minter account as a signer if it is not the payer. */
-  minter?: Signer;
+  minter?: PublicKey;
 };

--- a/clients/js/src/defaultGuards/allowList.ts
+++ b/clients/js/src/defaultGuards/allowList.ts
@@ -1,5 +1,5 @@
 import { getSplSystemProgramId } from '@metaplex-foundation/mpl-essentials';
-import { PublicKey, publicKey } from '@metaplex-foundation/umi';
+import { PublicKey, Signer, publicKey } from '@metaplex-foundation/umi';
 import {
   AllowList,
   AllowListArgs,
@@ -121,6 +121,10 @@ export type AllowListRouteArgs = AllowListArgs & {
    */
   merkleProof: Uint8Array[];
 
-  /** The minter account as a signer if it is not the payer. */
-  minter?: PublicKey;
+  /**
+   * The address of the minter to validate if it is not the payer.
+   * Here, we allow it to be a Signer for backwards compatibility
+   * but the account will not be used as a signer.
+   */
+  minter?: PublicKey | Signer;
 };

--- a/clients/js/test/route.test.ts
+++ b/clients/js/test/route.test.ts
@@ -2,6 +2,7 @@ import {
   base58PublicKey,
   generateSigner,
   none,
+  publicKey,
   sol,
   some,
   transactionBuilder,
@@ -38,7 +39,12 @@ test('it can call the route instruction of a specific guard', async (t) => {
       route(umi, {
         candyMachine,
         guard: 'allowList',
-        routeArgs: { path: 'proof', merkleRoot, merkleProof, minter },
+        routeArgs: {
+          path: 'proof',
+          merkleRoot,
+          merkleProof,
+          minter: publicKey(minter),
+        },
       })
     )
     .sendAndConfirm(umi);

--- a/clients/js/test/route.test.ts
+++ b/clients/js/test/route.test.ts
@@ -2,7 +2,6 @@ import {
   base58PublicKey,
   generateSigner,
   none,
-  publicKey,
   sol,
   some,
   transactionBuilder,
@@ -20,7 +19,7 @@ import { createUmi, createV1, createV2 } from './_setup';
 test('it can call the route instruction of a specific guard', async (t) => {
   // Given a candy machine with an allow list guard.
   const umi = await createUmi();
-  const minter = generateSigner(umi);
+  const minter = generateSigner(umi).publicKey;
   const allowedWallets = [
     base58PublicKey(minter),
     'Ur1CbWSGsXCdedknRbJsEk7urwAvu1uddmQv51nAnXB',
@@ -39,12 +38,7 @@ test('it can call the route instruction of a specific guard', async (t) => {
       route(umi, {
         candyMachine,
         guard: 'allowList',
-        routeArgs: {
-          path: 'proof',
-          merkleRoot,
-          merkleProof,
-          minter: publicKey(minter),
-        },
+        routeArgs: { path: 'proof', merkleRoot, merkleProof, minter },
       })
     )
     .sendAndConfirm(umi);
@@ -52,7 +46,7 @@ test('it can call the route instruction of a specific guard', async (t) => {
   // Then the allow list proof PDA was created.
   const allowListProofPda = findAllowListProofPda(umi, {
     merkleRoot,
-    user: minter.publicKey,
+    user: minter,
     candyMachine,
     candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
   });

--- a/programs/candy-guard/README.md
+++ b/programs/candy-guard/README.md
@@ -402,7 +402,7 @@ The `AllowList` guard validates the payer's address against a merkle tree-based 
 
 | Name        | Writable | Signer | Description                                                                                                            |
 | ----------- | :------: | :----: | ---------------------------------------------------------------------------------------------------------------------- |
-| `proof_pda` |          |        | PDA of the merkle proof (seed `["allow_list", merke tree root, payer key, candy guard pubkey, candy machine pubkey]`). |
+| `proof_pda` |          |        | PDA of the merkle proof (seed `["allow_list", merkle tree root, minter key, candy guard pubkey, candy machine pubkey]`). |
 
 </details>
 
@@ -415,9 +415,9 @@ The merkle proof validation needs to be completed before the mint transaction. T
 
 | Name             | Writable | Signer | Description                                                                                                                      |
 | ---------------- | :------: | :----: | -------------------------------------------------------------------------------------------------------------------------------- |
-| `proof_pda`      |    ✅    |        | PDA to represent the merkle proof (seed `["allow_list", merke tree root, payer key, candy guard pubkey, candy machine pubkey]`). |
+| `proof_pda`      |    ✅    |        | PDA to represent the merkle proof (seed `["allow_list", merkle tree root, payer/minter key, candy guard pubkey, candy machine pubkey]`). |
 | `system_program` |          |        | System program account.                                                                                                          |
-| `minter`         |          |   ✅   | (optional) Minter account to validate. |
+| `minter`         |          |        | (optional) Minter account to validate. |
 
 </details>
 <details>

--- a/programs/candy-guard/program/src/guards/allow_list.rs
+++ b/programs/candy-guard/program/src/guards/allow_list.rs
@@ -56,9 +56,9 @@ impl Guard for AllowList {
     /// List of accounts required:
     ///
     ///   0. `[writable]` Pda to represent the merkle proof (seeds `["allow_list", merke tree root,
-    ///                   payer key, candy guard pubkey, candy machine pubkey]`).
+    ///                   payer/minter key, candy guard pubkey, candy machine pubkey]`).
     ///   1. `[]` System program account.
-    ///   2. `[optional, signer]` Minter account.
+    ///   2. `[optional]` Minter account.
     fn instruction<'info>(
         ctx: &Context<'_, '_, '_, 'info, Route<'info>>,
         route_context: RouteContext<'info>,
@@ -86,11 +86,6 @@ impl Guard for AllowList {
         assert_keys_equal(system_program_info.key, &system_program::ID)?;
 
         let minter = if let Some(minter) = get_account_info(ctx.remaining_accounts, 2) {
-            if !minter.is_signer {
-                msg!("Minter is not a signer");
-                return err!(CandyGuardError::MissingRequiredSignature);
-            }
-
             minter.key()
         } else {
             ctx.accounts.payer.key()


### PR DESCRIPTION
This PR removes the signer requirement for the optional `minter` account on the allow list route instruction.