### PR TITLE
Close escrow token account on pNFT thaw

### DIFF
--- a/clients/js/test/defaultGuards/freezeSolPayment.test.ts
+++ b/clients/js/test/defaultGuards/freezeSolPayment.test.ts
@@ -822,16 +822,18 @@ test('it can thaw a Programmable NFT once all NFTs are minted', async (t) => {
   t.is(tokenRecordAccount.state, MetadataTokenState.Unlocked);
 
   // And the freeze escrow ATA account is closed.
-  t.false(await umi.rpc.accountExists(
-    findAssociatedTokenPda(umi, {
-      mint: mint.publicKey,
-      owner: findFreezeEscrowPda(umi, {
-        destination,
-        candyMachine,
-        candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
-      }),
-    })
-  ));
+  t.false(
+    await umi.rpc.accountExists(
+      findAssociatedTokenPda(umi, {
+        mint: mint.publicKey,
+        owner: findFreezeEscrowPda(umi, {
+          destination,
+          candyMachine,
+          candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
+        }),
+      })
+    )
+  );
 });
 
 const getFreezeEscrow = (

--- a/clients/js/test/defaultGuards/freezeSolPayment.test.ts
+++ b/clients/js/test/defaultGuards/freezeSolPayment.test.ts
@@ -820,6 +820,18 @@ test('it can thaw a Programmable NFT once all NFTs are minted', async (t) => {
   // Then the PNFT is unlocked.
   tokenRecordAccount = await fetchTokenRecord(umi, tokenRecord);
   t.is(tokenRecordAccount.state, MetadataTokenState.Unlocked);
+
+  // And the freeze escrow ATA account is closed.
+  t.false(await umi.rpc.accountExists(
+    findAssociatedTokenPda(umi, {
+      mint: mint.publicKey,
+      owner: findFreezeEscrowPda(umi, {
+        destination,
+        candyMachine,
+        candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
+      }),
+    })
+  ));
 });
 
 const getFreezeEscrow = (

--- a/clients/js/test/defaultGuards/freezeTokenPayment.test.ts
+++ b/clients/js/test/defaultGuards/freezeTokenPayment.test.ts
@@ -1010,6 +1010,18 @@ test('it can thaw a Programmable NFT once all NFTs are minted', async (t) => {
   // Then the PNFT is unlocked.
   tokenRecordAccount = await fetchTokenRecord(umi, tokenRecord);
   t.is(tokenRecordAccount.state, MetadataTokenState.Unlocked);
+
+  // And the freeze escrow ATA account is closed.
+  t.false(await umi.rpc.accountExists(
+    findAssociatedTokenPda(umi, {
+      mint: mint.publicKey,
+      owner: findFreezeEscrowPda(umi, {
+        destination: destinationAta,
+        candyMachine,
+        candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
+      }),
+    })
+  ));
 });
 
 const getTokenBalance = async (

--- a/clients/js/test/defaultGuards/freezeTokenPayment.test.ts
+++ b/clients/js/test/defaultGuards/freezeTokenPayment.test.ts
@@ -1012,16 +1012,18 @@ test('it can thaw a Programmable NFT once all NFTs are minted', async (t) => {
   t.is(tokenRecordAccount.state, MetadataTokenState.Unlocked);
 
   // And the freeze escrow ATA account is closed.
-  t.false(await umi.rpc.accountExists(
-    findAssociatedTokenPda(umi, {
-      mint: mint.publicKey,
-      owner: findFreezeEscrowPda(umi, {
-        destination: destinationAta,
-        candyMachine,
-        candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
-      }),
-    })
-  ));
+  t.false(
+    await umi.rpc.accountExists(
+      findAssociatedTokenPda(umi, {
+        mint: mint.publicKey,
+        owner: findFreezeEscrowPda(umi, {
+          destination: destinationAta,
+          candyMachine,
+          candyGuard: findCandyGuardPda(umi, { base: candyMachine }),
+        }),
+      })
+    )
+  );
 });
 
 const getTokenBalance = async (

--- a/programs/candy-guard/program/src/guards/freeze_sol_payment.rs
+++ b/programs/candy-guard/program/src/guards/freeze_sol_payment.rs
@@ -911,6 +911,24 @@ pub fn thaw_nft<'info>(
 
             invoke_signed(&transfer_in_ix, &transfer_accounts, &[&signer])?;
 
+            // closes the freeze escrow ATA
+
+            invoke_signed(
+                &spl_token::instruction::close_account(
+                    token_program.key,
+                    escrow_ata.key,
+                    ctx.accounts.payer.key,
+                    freeze_pda.key,
+                    &[],
+                )?,
+                &[
+                    escrow_ata.clone(),
+                    ctx.accounts.payer.to_account_info(),
+                    freeze_pda.clone(),
+                ],
+                &[&signer],
+            )?;
+
             // decreases the freeze (lock) counter
             freeze_escrow.frozen_count = freeze_escrow.frozen_count.saturating_sub(1);
         } else {


### PR DESCRIPTION
This PR closes the escrow ATA after a pNFT is thaw.