### PR TITLE
chore: ignore yarn temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 .amman
 .crates
 .vscode
+.yarn


### PR DESCRIPTION
Pretty sure I added this in [metaplex-foundation/mpl-candy-guard](https://github.com/metaplex-foundation/mpl-candy-guard) but didn't make it across.