### PR TITLE
Add additional addresses to LUT

### DIFF
--- a/clients/js/src/createLutForCandyMachine.ts
+++ b/clients/js/src/createLutForCandyMachine.ts
@@ -6,7 +6,12 @@ import {
   findMetadataPda,
   getMplTokenMetadataProgramId,
 } from '@metaplex-foundation/mpl-token-metadata';
-import { createLut, getSysvar, getSplAssociatedTokenProgramId, getSplTokenProgramId } from '@metaplex-foundation/mpl-toolbox';
+import {
+  createLut,
+  getSysvar,
+  getSplAssociatedTokenProgramId,
+  getSplTokenProgramId,
+} from '@metaplex-foundation/mpl-toolbox';
 import {
   AddressLookupTableInput,
   Context,
@@ -15,7 +20,11 @@ import {
   TransactionBuilder,
   uniquePublicKeys,
 } from '@metaplex-foundation/umi';
-import { AccountVersion, fetchCandyMachine, getMplCandyMachineCoreProgramId } from './generated';
+import {
+  AccountVersion,
+  fetchCandyMachine,
+  getMplCandyMachineCoreProgramId,
+} from './generated';
 import { findCandyMachineAuthorityPda } from './hooked';
 
 export const createLutForCandyMachine = async (

--- a/clients/js/src/createLutForCandyMachine.ts
+++ b/clients/js/src/createLutForCandyMachine.ts
@@ -4,8 +4,9 @@ import {
   findMasterEditionPda,
   findMetadataDelegateRecordPda,
   findMetadataPda,
+  getMplTokenMetadataProgramId,
 } from '@metaplex-foundation/mpl-token-metadata';
-import { createLut, getSysvar } from '@metaplex-foundation/mpl-toolbox';
+import { createLut, getSysvar, getSplAssociatedTokenProgramId, getSplTokenProgramId } from '@metaplex-foundation/mpl-toolbox';
 import {
   AddressLookupTableInput,
   Context,
@@ -14,7 +15,7 @@ import {
   TransactionBuilder,
   uniquePublicKeys,
 } from '@metaplex-foundation/umi';
-import { AccountVersion, fetchCandyMachine } from './generated';
+import { AccountVersion, fetchCandyMachine, getMplCandyMachineCoreProgramId } from './generated';
 import { findCandyMachineAuthorityPda } from './hooked';
 
 export const createLutForCandyMachine = async (
@@ -72,5 +73,9 @@ export const getLutAddressesForCandyMachine = async (
       : delegateRecordV2,
     getSysvar('instructions'),
     getSysvar('slotHashes'),
+    getSplTokenProgramId(context),
+    getSplAssociatedTokenProgramId(context),
+    getMplTokenMetadataProgramId(context),
+    getMplCandyMachineCoreProgramId(context),
   ]);
 };

--- a/clients/js/test/createLutForCandyMachine.test.ts
+++ b/clients/js/test/createLutForCandyMachine.test.ts
@@ -5,8 +5,11 @@ import {
   findMasterEditionPda,
   findMetadataDelegateRecordPda,
   findMetadataPda,
+  getMplTokenMetadataProgramId,
 } from '@metaplex-foundation/mpl-token-metadata';
 import {
+  getSplAssociatedTokenProgramId,
+  getSplTokenProgramId,
   getSysvar,
   setComputeUnitLimit,
 } from '@metaplex-foundation/mpl-toolbox';
@@ -16,6 +19,7 @@ import {
   createLutForCandyMachine,
   findCandyGuardPda,
   findCandyMachineAuthorityPda,
+  getMplCandyMachineCoreProgramId,
   mintV2,
   setMintAuthority,
 } from '../src';
@@ -81,6 +85,10 @@ test('it can create a LUT for a candy machine v2', async (t) => {
       })[0],
       getSysvar('instructions'),
       getSysvar('slotHashes'),
+      getSplTokenProgramId(umi),
+      getSplAssociatedTokenProgramId(umi),
+      getMplTokenMetadataProgramId(umi),
+      getMplCandyMachineCoreProgramId(umi),
     ].sort()
   );
 
@@ -90,7 +98,7 @@ test('it can create a LUT for a candy machine v2', async (t) => {
     builderWithoutLut.getTransactionSize(umi) -
     builderWithLut.getTransactionSize(umi);
   const expectedSizeDifference =
-    (32 - 1) * 9 + // Replaces keys with indexes for 9 out of 10 addresses (one is a Signer).
+    (32 - 1) * 13 + // Replaces keys with indexes for 13 out of 14 addresses (one is a Signer).
     -32 + // Adds 32 bytes for the LUT address itself.
     -2; // Adds 2 bytes for writable and readonly array sizes.
   t.is(transactionSizeDifference, expectedSizeDifference);


### PR DESCRIPTION
These four accounts are used in most of the instructions, especially the mint instruction where the biggest need for LUTs exist.

Proof that these Adresses would actually be used from LUT: https://explorer.solana.com/tx/5cpjLqgw74VxGV8PWkhosYRURSn7ScB2FUaSzDZuSHmc94qdbrb49XhFi1MuNKFRMrrwqkxgz3p2brm5AUDrg2cG?cluster=devnet

